### PR TITLE
Remove autoversioning from dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -3,11 +3,11 @@ author  = John Tate <jt6@sanger.ac.uk>
 license = GPL_3
 copyright_holder = Wellcome Trust Sanger Institute
 copyright_year   = 2015
+version = 0.1.0
 
 [@Git]
 [@Starter]
 [AutoPrereqs]
-[AutoVersion]
 [PodWeaver]
 
 [Encoding]


### PR DESCRIPTION
Update version manually to keep versioning consistent for conda